### PR TITLE
fix: bump redis to 3.1.2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,5 @@
   "trailingComma": "es5",
   "bracketSpacing": false,
   "arrowParens": "always",
-  "endOfLine": "lf"
+  "endOfLine": "auto"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,9 +155,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
         },
         "semver": {
@@ -1686,19 +1686,19 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.8.tgz",
-      "integrity": "sha512-8c1TLwKB/xT5E1FNs5l4GFtaNTznHesJk7tw3pGSlVxRqDXa1EZI+DfziZlO58Wk3PpS2ecu661kvBdz9aMgYQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.3.tgz",
+      "integrity": "sha512-x52kQ/jR09WjuWdaTEHgQCvZYMOTx68WnS+TZ4fya5ZAJw4oRtJETtrvUw10FdfM28d/keInQdc66R1Gw5+OEQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
         "aggregate-error": "^3.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^10.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^5.0.0",
-        "npm": "^6.14.8",
+        "normalize-url": "^6.0.0",
+        "npm": "^7.0.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1718,35 +1718,49 @@
           }
         },
         "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
             "is-stream": "^2.0.0",
             "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
             "strip-final-newline": "^2.0.0"
           }
         },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "mimic-fn": {
@@ -1774,9 +1788,9 @@
           }
         },
         "parse-json": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -1804,12 +1818,12 @@
           }
         },
         "registry-auth-token": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-          "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+          "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
           "dev": true,
           "requires": {
-            "rc": "^1.2.8"
+            "rc": "1.2.8"
           }
         },
         "shebang-command": {
@@ -1827,10 +1841,22 @@
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+          "dev": true
+        },
         "type-fest": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         },
         "which": {
@@ -3363,9 +3389,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -3775,9 +3801,9 @@
           }
         },
         "trim-newlines": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-          "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
           "dev": true
         },
         "type-fest": {
@@ -4007,9 +4033,9 @@
           }
         },
         "trim-newlines": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-          "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
           "dev": true
         },
         "type-fest": {
@@ -4312,9 +4338,9 @@
       }
     },
     "del": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
       "dev": true,
       "requires": {
         "globby": "^11.0.1",
@@ -4333,52 +4359,108 @@
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.12",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+          "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
         "globby": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
             "slash": "^3.0.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "dev": true
         },
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
         },
-        "is-path-inside": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
+        },
+        "is-path-inside": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
+          }
         },
         "p-map": {
           "version": "4.0.0",
@@ -4389,22 +4471,33 @@
             "aggregate-error": "^3.0.0"
           }
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
         },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -4461,11 +4554,6 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -4799,9 +4887,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -5256,9 +5344,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -5267,13 +5355,13 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -6360,9 +6448,9 @@
           }
         },
         "trim-newlines": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-          "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
           "dev": true
         },
         "type-fest": {
@@ -6487,9 +6575,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -6500,9 +6588,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
         },
         "source-map": {
@@ -6655,9 +6743,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-escaper": {
@@ -6829,9 +6917,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "into-stream": {
@@ -7556,9 +7644,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -7922,9 +8010,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
         },
         "path-exists": {
@@ -8055,9 +8143,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "minimist-options": {
@@ -8101,12 +8189,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.6"
       }
     },
     "modify-values": {
@@ -8194,7 +8282,7 @@
     "nerf-dart": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
-      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true
     },
     "nise": {
@@ -8231,10 +8319,13 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -8275,150 +8366,267 @@
       }
     },
     "normalize-url": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
-      "integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
     },
     "npm": {
-      "version": "6.14.8",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
-      "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.5",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^2.9.0",
+        "@npmcli/ci-detect": "^1.2.0",
+        "@npmcli/config": "^2.3.0",
+        "@npmcli/map-workspaces": "^1.0.4",
+        "@npmcli/package-json": "^1.0.1",
+        "@npmcli/run-script": "^1.8.6",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.8",
-        "bluebird": "^3.5.5",
-        "byte-size": "^5.0.1",
-        "cacache": "^12.0.3",
-        "call-limit": "^1.1.1",
-        "chownr": "^1.1.4",
-        "ci-info": "^2.0.0",
+        "cacache": "^15.3.0",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.1",
-        "cmd-shim": "^3.0.3",
+        "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
-        "config-chain": "^1.1.12",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.5.1",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.3.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
-        "iferr": "^1.0.2",
-        "imurmurhash": "*",
-        "infer-owner": "^1.0.4",
-        "inflight": "~1.0.6",
-        "inherits": "^2.0.4",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^3.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.8",
-        "libnpm": "^3.0.1",
-        "libnpmaccess": "^3.0.2",
-        "libnpmhook": "^5.0.3",
-        "libnpmorg": "^1.0.1",
-        "libnpmsearch": "^2.0.2",
-        "libnpmteam": "^1.0.2",
-        "libnpx": "^10.2.4",
-        "lock-verify": "^2.1.0",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^5.1.1",
-        "meant": "^1.0.2",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.5",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.1.0",
-        "nopt": "^4.0.3",
-        "normalize-package-data": "^2.5.0",
-        "npm-audit-report": "^1.3.3",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "^3.1.5",
-        "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.8",
-        "npm-pick-manifest": "^3.0.2",
-        "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.7",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "^1.5.1",
-        "osenv": "^0.1.5",
-        "pacote": "^9.5.12",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
+        "fastest-levenshtein": "^1.0.12",
+        "glob": "^7.2.0",
+        "graceful-fs": "^4.2.8",
+        "hosted-git-info": "^4.0.2",
+        "ini": "^2.0.0",
+        "init-package-json": "^2.0.5",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^4.0.2",
+        "libnpmdiff": "^2.0.4",
+        "libnpmexec": "^2.0.1",
+        "libnpmfund": "^1.1.0",
+        "libnpmhook": "^6.0.2",
+        "libnpmorg": "^2.0.2",
+        "libnpmpack": "^2.0.1",
+        "libnpmpublish": "^4.0.1",
+        "libnpmsearch": "^3.1.1",
+        "libnpmteam": "^2.0.3",
+        "libnpmversion": "^1.2.1",
+        "make-fetch-happen": "^9.1.0",
+        "minipass": "^3.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^7.1.2",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^2.1.5",
+        "npm-install-checks": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.3",
+        "npm-registry-fetch": "^11.0.0",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^5.0.1",
+        "opener": "^1.5.2",
+        "pacote": "^11.3.5",
+        "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.2",
-        "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.5",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.1",
-        "read-package-tree": "^5.3.1",
-        "readable-stream": "^3.6.0",
+        "read-package-json": "^4.1.1",
+        "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
-        "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "rimraf": "^2.7.1",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.7.1",
-        "sha": "^3.0.0",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
-        "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "^1.1.1",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.3",
-        "validate-npm-package-license": "^3.0.4",
+        "treeverse": "^1.0.4",
         "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.7.0",
-        "write-file-atomic": "^2.4.3"
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.5",
+        "@gar/promisify": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@isaacs/string-locale-compare": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/arborist": {
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "@isaacs/string-locale-compare": "^1.0.1",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/map-workspaces": "^1.0.2",
+            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/move-file": "^1.1.0",
+            "@npmcli/name-from-folder": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/package-json": "^1.0.1",
+            "@npmcli/run-script": "^1.8.2",
+            "bin-links": "^2.2.1",
+            "cacache": "^15.0.3",
+            "common-ancestor-path": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-install-checks": "^4.0.0",
+            "npm-package-arg": "^8.1.5",
+            "npm-pick-manifest": "^6.1.0",
+            "npm-registry-fetch": "^11.0.0",
+            "pacote": "^11.3.5",
+            "parse-conflict-json": "^1.1.1",
+            "proc-log": "^1.0.0",
+            "promise-all-reject-late": "^1.0.0",
+            "promise-call-limit": "^1.0.1",
+            "read-package-json-fast": "^2.0.2",
+            "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.5",
+            "ssri": "^8.0.1",
+            "treeverse": "^1.0.4",
+            "walk-up-path": "^1.0.0"
           }
+        },
+        "@npmcli/ci-detect": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/config": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^2.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
+            "semver": "^7.3.4",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "@npmcli/disparity-colors": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.3.0"
+          }
+        },
+        "@npmcli/fs": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.0.1",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^1.3.2",
+            "lru-cache": "^6.0.0",
+            "mkdirp": "^1.0.4",
+            "npm-pick-manifest": "^6.1.1",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^2.0.2"
+          }
+        },
+        "@npmcli/installed-package-contents": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "@npmcli/map-workspaces": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/name-from-folder": "^1.0.1",
+            "glob": "^7.1.6",
+            "minimatch": "^3.0.4",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@npmcli/metavuln-calculator": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^15.0.5",
+            "pacote": "^11.1.11",
+            "semver": "^7.3.2"
+          }
+        },
+        "@npmcli/move-file": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "@npmcli/name-from-folder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/node-gyp": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/package-json": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1"
+          }
+        },
+        "@npmcli/promise-spawn": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "infer-owner": "^1.0.4"
+          }
+        },
+        "@npmcli/run-script": {
+          "version": "1.8.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/node-gyp": "^1.0.2",
+            "@npmcli/promise-spawn": "^1.3.2",
+            "node-gyp": "^7.1.0",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
@@ -8426,38 +8634,41 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.3.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
           }
         },
         "agentkeepalive": {
-          "version": "3.5.2",
+          "version": "4.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
+            "debug": "^4.1.0",
+            "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
           }
         },
-        "ajv": {
-          "version": "5.5.2",
+        "aggregate-error": {
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
           }
         },
-        "ansi-align": {
-          "version": "2.0.0",
+        "ajv": {
+          "version": "6.12.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -8466,11 +8677,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "^2.0.1"
           }
         },
         "ansicolors": {
@@ -8494,36 +8705,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "readable-stream": "^3.6.0"
           }
         },
         "asap": {
@@ -8555,12 +8742,12 @@
           "dev": true
         },
         "aws4": {
-          "version": "1.8.0",
+          "version": "1.11.0",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
@@ -8568,42 +8755,27 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
-          "version": "1.1.8",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cmd-shim": "^3.0.0",
-            "gentle-fs": "^2.3.0",
-            "graceful-fs": "^4.1.15",
+            "cmd-shim": "^4.0.1",
+            "mkdirp": "^1.0.3",
             "npm-normalize-package-bin": "^1.0.0",
-            "write-file-atomic": "^2.3.0"
+            "read-cmd-shim": "^2.0.0",
+            "rimraf": "^3.0.0",
+            "write-file-atomic": "^3.0.3"
           }
         },
-        "bluebird": {
-          "version": "3.5.5",
+        "binary-extensions": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -8614,62 +8786,35 @@
             "concat-map": "0.0.1"
           }
         },
-        "buffer-from": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
-        "byline": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "byte-size": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "cacache": {
-          "version": "12.0.3",
+          "version": "15.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
+            "@npmcli/fs": "^1.0.0",
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
           }
-        },
-        "call-limit": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -8677,35 +8822,29 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.4.1",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "chownr": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ci-info": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
-          "version": "2.0.10",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "^4.1.0"
           }
         },
-        "cli-boxes": {
-          "version": "1.0.0",
+        "clean-stack": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -8719,51 +8858,41 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
-          }
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "string-width": "^4.2.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
-              "version": "2.0.0",
+              "version": "3.0.0",
               "bundled": true,
               "dev": true
             },
             "string-width": {
-              "version": "3.1.0",
+              "version": "4.2.2",
               "bundled": true,
               "dev": true,
               "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
               }
             },
             "strip-ansi": {
-              "version": "5.2.0",
+              "version": "6.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.1.0"
+                "ansi-regex": "^5.0.0"
               }
             }
           }
@@ -8774,18 +8903,12 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "3.0.3",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "mkdirp-infer-owner": "^2.0.0"
           }
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -8793,20 +8916,25 @@
           "dev": true
         },
         "color-convert": {
-          "version": "1.9.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "color-support": {
           "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
         "colors": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -8821,151 +8949,30 @@
           }
         },
         "combined-stream": {
-          "version": "1.0.6",
+          "version": "1.0.8",
           "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
+        "common-ancestor-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
           "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
-          }
-        },
-        "configstore": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.2.1",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
-        "copy-concurrently": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cyclist": {
-          "version": "0.2.2",
           "bundled": true,
           "dev": true
         },
@@ -8978,15 +8985,15 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
-              "version": "2.0.0",
+              "version": "2.1.2",
               "bundled": true,
               "dev": true
             }
@@ -8997,35 +9004,12 @@
           "bundled": true,
           "dev": true
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true
-        },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
-          }
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -9038,13 +9022,8 @@
           "bundled": true,
           "dev": true
         },
-        "detect-indent": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "detect-newline": {
-          "version": "2.1.0",
+        "depd": {
+          "version": "1.1.2",
           "bundled": true,
           "dev": true
         },
@@ -9057,173 +9036,43 @@
             "wrappy": "1"
           }
         },
-        "dot-prop": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
+        "diff": {
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "duplexify": {
-          "version": "3.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
           }
         },
-        "editor": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "emoji-regex": {
-          "version": "7.0.3",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true
         },
         "encoding": {
-          "version": "0.1.12",
+          "version": "0.1.13",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
+            "iconv-lite": "^0.6.2"
           }
         },
         "env-paths": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true
         },
         "err-code": {
-          "version": "1.1.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
-        },
-        "errno": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prr": "~1.0.1"
-          }
-        },
-        "es-abstract": {
-          "version": "1.12.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.1.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1",
-            "is-callable": "^1.1.3",
-            "is-regex": "^1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "es6-promise": {
-          "version": "4.2.8",
-          "bundled": true,
-          "dev": true
-        },
-        "es6-promisify": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es6-promise": "^4.0.3"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "extend": {
           "version": "3.0.2",
@@ -9236,173 +9085,31 @@
           "dev": true
         },
         "fast-deep-equal": {
-          "version": "1.1.0",
+          "version": "3.1.3",
           "bundled": true,
           "dev": true
         },
         "fast-json-stable-stringify": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true
         },
-        "figgy-pudding": {
-          "version": "3.5.1",
+        "fastest-levenshtein": {
+          "version": "1.0.12",
           "bundled": true,
           "dev": true
-        },
-        "find-npm-prefix": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "flush-write-stream": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
           "dev": true
         },
-        "form-data": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "from2": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
         "fs-minipass": {
-          "version": "1.2.7",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.6.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "fs-vacuum": {
-          "version": "1.2.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          },
-          "dependencies": {
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -9416,83 +9123,19 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "genfun": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "gentle-fs": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.2",
-            "chownr": "^1.1.2",
-            "cmd-shim": "^3.0.3",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "infer-owner": "^1.0.4",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
+            "string-width": "^1.0.1 || ^2.0.0",
+            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "wide-align": "^1.1.2"
           }
         },
         "getpass": {
@@ -9504,7 +9147,7 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9516,41 +9159,8 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "graceful-fs": {
-          "version": "4.2.4",
+          "version": "4.2.8",
           "bundled": true,
           "dev": true
         },
@@ -9560,11 +9170,11 @@
           "dev": true
         },
         "har-validator": {
-          "version": "5.1.0",
+          "version": "5.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ajv": "^5.3.0",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
         },
@@ -9577,12 +9187,7 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "has-symbols": {
-          "version": "1.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -9592,22 +9197,26 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
+          "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "http-cache-semantics": {
-          "version": "3.8.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
-          "version": "2.1.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "http-signature": {
@@ -9621,12 +9230,12 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "humanize-ms": {
@@ -9638,33 +9247,29 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.6.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "iferr": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "ignore-walk": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
-        "import-lazy": {
-          "version": "2.1.0",
+        "imurmurhash": {
+          "version": "0.1.4",
           "bundled": true,
           "dev": true
         },
-        "imurmurhash": {
-          "version": "0.1.4",
+        "indent-string": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -9688,22 +9293,21 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.5",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "1.10.3",
+          "version": "2.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npm-package-arg": "^8.1.5",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
+            "read-package-json": "^4.1.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
@@ -9713,115 +9317,37 @@
           "dev": true
         },
         "ip-regex": {
-          "version": "2.1.0",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
-          },
-          "dependencies": {
-            "ci-info": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "is-cidr": {
-          "version": "3.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^2.0.10"
+            "cidr-regex": "^3.1.1"
           }
         },
-        "is-date-object": {
-          "version": "1.0.1",
+        "is-core-module": {
+          "version": "2.7.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
-        "is-obj": {
+        "is-lambda": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-retry-allowed": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
         },
         "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
@@ -9839,11 +9365,10 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
           "bundled": true,
           "dev": true
         },
@@ -9853,7 +9378,12 @@
           "dev": true
         },
         "json-schema-traverse": {
-          "version": "0.3.1",
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-nice": {
+          "version": "1.1.4",
           "bundled": true,
           "dev": true
         },
@@ -9878,347 +9408,179 @@
             "verror": "1.10.0"
           }
         },
-        "latest-version": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "lazy-property": {
-          "version": "1.0.0",
+        "just-diff": {
+          "version": "3.1.1",
           "bundled": true,
           "dev": true
         },
-        "libcipm": {
-          "version": "4.0.8",
+        "just-diff-apply": {
+          "version": "3.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "ini": "^1.3.5",
-            "lock-verify": "^2.1.0",
-            "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^9.1.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
-          }
-        },
-        "libnpm": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.3",
-            "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.2",
-            "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.3",
-            "libnpmorg": "^1.0.1",
-            "libnpmpublish": "^1.1.2",
-            "libnpmsearch": "^2.0.2",
-            "libnpmteam": "^1.0.2",
-            "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.2",
-            "npm-registry-fetch": "^4.0.0",
-            "npmlog": "^4.1.2",
-            "pacote": "^9.5.3",
-            "read-package-json": "^2.0.13",
-            "stringify-package": "^1.0.0"
-          }
+          "dev": true
         },
         "libnpmaccess": {
-          "version": "3.0.2",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "get-stream": "^4.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0"
+            "minipass": "^3.1.1",
+            "npm-package-arg": "^8.1.2",
+            "npm-registry-fetch": "^11.0.0"
           }
         },
-        "libnpmconfig": {
-          "version": "1.2.1",
+        "libnpmdiff": {
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "find-up": "^3.0.0",
-            "ini": "^1.3.5"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "@npmcli/disparity-colors": "^1.0.1",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "binary-extensions": "^2.2.0",
+            "diff": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
+            "tar": "^6.1.0"
+          }
+        },
+        "libnpmexec": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^2.3.0",
+            "@npmcli/ci-detect": "^1.3.0",
+            "@npmcli/run-script": "^1.8.4",
+            "chalk": "^4.1.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-package-arg": "^8.1.2",
+            "pacote": "^11.3.1",
+            "proc-log": "^1.0.0",
+            "read": "^1.0.7",
+            "read-package-json-fast": "^2.0.2",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "libnpmfund": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^2.5.0"
           }
         },
         "libnpmhook": {
-          "version": "5.0.3",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmorg": {
-          "version": "1.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^11.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^1.8.3",
+            "npm-package-arg": "^8.1.0",
+            "pacote": "^11.2.6"
           }
         },
         "libnpmpublish": {
-          "version": "1.1.2",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "lodash.clonedeep": "^4.5.0",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0",
-            "semver": "^5.5.1",
-            "ssri": "^6.0.1"
+            "normalize-package-data": "^3.0.2",
+            "npm-package-arg": "^8.1.2",
+            "npm-registry-fetch": "^11.0.0",
+            "semver": "^7.1.3",
+            "ssri": "^8.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmteam": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpx": {
-          "version": "10.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^14.2.3"
-          }
-        },
-        "lock-verify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-package-arg": "^6.1.0",
-            "semver": "^5.4.1"
-          }
-        },
-        "lockfile": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._baseuniq": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
-        "lodash._createset": {
-          "version": "4.0.3",
+        "libnpmteam": {
+          "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^11.0.0"
+          }
         },
-        "lodash._getnative": {
-          "version": "3.9.1",
+        "libnpmversion": {
+          "version": "1.2.1",
           "bundled": true,
-          "dev": true
-        },
-        "lodash._root": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.union": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.without": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "@npmcli/git": "^2.0.7",
+            "@npmcli/run-script": "^1.8.4",
+            "json-parse-even-better-errors": "^2.3.1",
+            "semver": "^7.3.5",
+            "stringify-package": "^1.0.1"
+          }
         },
         "lru-cache": {
-          "version": "5.1.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
+            "yallist": "^4.0.0"
           }
         },
         "make-fetch-happen": {
-          "version": "5.0.2",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^12.0.0",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "^4.1.3",
+            "cacache": "^15.2.0",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.3",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^1.3.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.2",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^6.0.0",
+            "ssri": "^8.0.0"
           }
         },
-        "meant": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "mime-db": {
-          "version": "1.35.0",
+          "version": "1.49.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.19",
+          "version": "2.1.32",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "1.49.0"
           }
         },
         "minimatch": {
@@ -10229,199 +9591,215 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true
-        },
-        "minizlib": {
-          "version": "1.3.3",
+        "minipass": {
+          "version": "3.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.9.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "yallist": "^4.0.0"
           }
         },
-        "mississippi": {
-          "version": "3.0.0",
+        "minipass-collect": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "minipass": "^3.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.5",
+        "minipass-fetch": {
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true
-            }
+            "encoding": "^0.1.12",
+            "minipass": "^3.1.0",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.0.0"
           }
         },
-        "move-concurrently": {
+        "minipass-flush": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "jsonparse": "^1.3.1",
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-pipeline": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-sized": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp-infer-owner": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "bundled": true,
+          "dev": true
+        },
+        "node-gyp": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.3",
+            "nopt": "^5.0.0",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.2",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.2",
+            "tar": "^6.0.2",
+            "which": "^2.0.2"
           },
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
               "bundled": true,
               "dev": true
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "node-fetch-npm": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "node-gyp": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "semver": "^5.7.1",
-            "tar": "^4.4.12",
-            "which": "^1.3.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "1.10.0",
+            },
+            "gauge": {
+              "version": "2.7.4",
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-parse": "^1.0.6"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
         },
-        "npm-audit-report": {
-          "version": "1.3.3",
+        "nopt": {
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "abbrev": "1"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-audit-report": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
           }
         },
         "npm-bundled": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "npm-install-checks": {
-          "version": "3.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "^7.1.1"
           }
-        },
-        "npm-lifecycle": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.15",
-            "node-gyp": "^5.0.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.1"
-          }
-        },
-        "npm-logical-tree": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
@@ -10429,89 +9807,83 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "6.1.1",
+          "version": "8.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.7.1",
-            "osenv": "^0.1.5",
-            "semver": "^5.6.0",
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.8",
+          "version": "2.2.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1",
+            "glob": "^7.1.6",
+            "ignore-walk": "^3.0.3",
+            "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "3.0.2",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-install-checks": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1",
+            "npm-package-arg": "^8.1.2",
+            "semver": "^7.3.4"
           }
         },
         "npm-profile": {
-          "version": "4.0.4",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.7",
+          "version": "11.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "JSONStream": "^1.3.4",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.4.1",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "npm-package-arg": "^6.1.0",
-            "safe-buffer": "^5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
+            "make-fetch-happen": "^9.0.1",
+            "minipass": "^3.1.3",
+            "minipass-fetch": "^1.3.0",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.0.0",
+            "npm-package-arg": "^8.0.0"
           }
         },
         "npm-user-validate": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
           }
         },
         "number-is-nan": {
@@ -10529,20 +9901,6 @@
           "bundled": true,
           "dev": true
         },
-        "object-keys": {
-          "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.1"
-          }
-        },
         "once": {
           "version": "1.4.0",
           "bundled": true,
@@ -10552,149 +9910,56 @@
           }
         },
         "opener": {
-          "version": "1.5.1",
+          "version": "1.5.2",
           "bundled": true,
           "dev": true
         },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "osenv": {
-          "version": "0.1.5",
+        "p-map": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "aggregate-error": "^3.0.0"
           }
         },
         "pacote": {
-          "version": "9.5.12",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cacache": "^12.0.2",
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.1.0",
-            "glob": "^7.1.3",
+            "@npmcli/git": "^2.1.0",
+            "@npmcli/installed-package-contents": "^1.0.6",
+            "@npmcli/promise-spawn": "^1.2.0",
+            "@npmcli/run-script": "^1.8.2",
+            "cacache": "^15.0.5",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.5",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-normalize-package-bin": "^1.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^3.0.0",
-            "npm-registry-fetch": "^4.0.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.1",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.6.0",
-            "ssri": "^6.0.1",
-            "tar": "^4.4.10",
-            "unique-filename": "^1.1.1",
-            "which": "^1.3.1"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "minipass": "^3.1.3",
+            "mkdirp": "^1.0.3",
+            "npm-package-arg": "^8.0.1",
+            "npm-packlist": "^2.1.4",
+            "npm-pick-manifest": "^6.0.0",
+            "npm-registry-fetch": "^11.0.0",
+            "promise-retry": "^2.0.1",
+            "read-package-json-fast": "^2.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.1.0"
           }
         },
-        "parallel-transform": {
-          "version": "1.1.0",
+        "parse-conflict-json": {
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "json-parse-even-better-errors": "^2.3.0",
+            "just-diff": "^3.0.1",
+            "just-diff-apply": "^3.0.0"
           }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.6",
           "bundled": true,
           "dev": true
         },
@@ -10703,18 +9968,18 @@
           "bundled": true,
           "dev": true
         },
-        "pify": {
-          "version": "3.0.0",
+        "proc-log": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "prepend-http": {
-          "version": "1.0.4",
+        "promise-all-reject-late": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
-        "process-nextick-args": {
-          "version": "2.0.0",
+        "promise-call-limit": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
@@ -10724,19 +9989,12 @@
           "dev": true
         },
         "promise-retry": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true,
-              "dev": true
-            }
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
           }
         },
         "promzard": {
@@ -10747,66 +10005,13 @@
             "read": "1"
           }
         },
-        "proto-list": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "protoduck": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "genfun": "^5.0.0"
-          }
-        },
-        "prr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "psl": {
-          "version": "1.1.29",
+          "version": "1.8.0",
           "bundled": true,
           "dev": true
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
         },
         "punycode": {
-          "version": "1.4.1",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -10820,32 +10025,6 @@
           "bundled": true,
           "dev": true
         },
-        "query-string": {
-          "version": "6.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          }
-        },
-        "qw": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
@@ -10855,47 +10034,28 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.5",
+          "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
-          }
+          "dev": true
         },
         "read-package-json": {
-          "version": "2.1.1",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
+            "json-parse-even-better-errors": "^2.3.0",
+            "normalize-package-data": "^3.0.0",
             "npm-normalize-package-bin": "^1.0.0"
           }
         },
-        "read-package-tree": {
-          "version": "5.3.1",
+        "read-package-json-fast": {
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "util-promisify": "^2.1.0"
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "readable-stream": {
@@ -10919,25 +10079,8 @@
             "once": "^1.3.0"
           }
         },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
         "request": {
-          "version": "2.88.0",
+          "version": "2.88.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10948,7 +10091,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
+            "har-validator": "~5.1.3",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -10958,25 +10101,31 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
+            "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            }
           }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
         },
         "retry": {
           "version": "0.12.0",
@@ -10984,30 +10133,15 @@
           "dev": true
         },
         "rimraf": {
-          "version": "2.7.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
-        "run-queue": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true
         },
@@ -11017,16 +10151,11 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
+          "version": "7.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^5.0.3"
+            "lru-cache": "^6.0.0"
           }
         },
         "set-blocking": {
@@ -11034,118 +10163,37 @@
           "bundled": true,
           "dev": true
         },
-        "sha": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
         "socks": {
-          "version": "2.3.3",
+          "version": "2.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
+            "ip": "^1.1.5",
             "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.2",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "~4.2.1",
-            "socks": "~2.3.2"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "4.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            }
-          }
-        },
-        "sorted-object": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true,
-              "dev": true
-            }
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11154,12 +10202,12 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11168,17 +10216,12 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "split-on-first": {
-          "version": "1.1.0",
+          "version": "3.0.10",
           "bundled": true,
           "dev": true
         },
         "sshpk": {
-          "version": "1.14.2",
+          "version": "1.16.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11194,64 +10237,12 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
+          "version": "8.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1"
+            "minipass": "^3.1.1"
           }
-        },
-        "stream-each": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "stream-iterate": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strict-uri-encode": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
@@ -11264,11 +10255,6 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
               "bundled": true,
               "dev": true
             },
@@ -11288,13 +10274,6 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "stringify-package": {
@@ -11310,102 +10289,29 @@
             "ansi-regex": "^2.0.0"
           }
         },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "supports-color": {
-          "version": "5.4.0",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "6.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0"
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
@@ -11414,14 +10320,10 @@
           "bundled": true,
           "dev": true
         },
-        "tough-cookie": {
-          "version": "2.4.3",
+        "treeverse": {
+          "version": "1.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+          "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
@@ -11434,23 +10336,15 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "bundled": true,
           "dev": true,
-          "optional": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
         },
         "unique-filename": {
           "version": "1.1.1",
@@ -11461,54 +10355,19 @@
           }
         },
         "unique-slug": {
-          "version": "2.0.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
-        "unique-string": {
-          "version": "1.0.0",
+        "uri-js": {
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
+            "punycode": "^2.1.0"
           }
         },
         "util-deprecate": {
@@ -11516,21 +10375,8 @@
           "bundled": true,
           "dev": true
         },
-        "util-extend": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "util-promisify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object.getownpropertydescriptors": "^2.0.3"
-          }
-        },
         "uuid": {
-          "version": "3.3.3",
+          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -11561,6 +10407,11 @@
             "extsprintf": "^1.2.0"
           }
         },
+        "walk-up-path": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
@@ -11570,92 +10421,19 @@
           }
         },
         "which": {
-          "version": "1.3.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "widest-line": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "worker-farm": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -11664,136 +10442,20 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "2.4.3",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "y18n": {
+        "yallist": {
           "version": "4.0.0",
           "bundled": true,
           "dev": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -12369,9 +11031,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -12649,9 +11311,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
         }
       }
@@ -13033,24 +11695,33 @@
       }
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
     },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -13441,8 +12112,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ansi-styles": {
@@ -13896,9 +12566,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "serialize-error": {
@@ -14917,9 +13587,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -14998,9 +13668,9 @@
       "dev": true
     },
     "tempy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.0.tgz",
-      "integrity": "sha512-eLXG5B1G0mRPHmgH2WydPl5v4jH35qEn3y/rA/aahKhIa91Pn119SsU7n7v/433gtT9ONzC8ISvNHIh2JSTm0w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
       "dev": true,
       "requires": {
         "del": "^6.0.0",
@@ -15017,9 +13687,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "type-fest": {
@@ -15147,6 +13817,12 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -15160,9 +13836,9 @@
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true
     },
     "trim-right": {
@@ -15202,9 +13878,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.4.tgz",
-      "integrity": "sha512-FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
+      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
       "dev": true,
       "optional": true
     },
@@ -15392,11 +14068,27 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
     "well-known-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
       "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.0",
@@ -15431,7 +14123,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -15446,9 +14138,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -15572,9 +14264,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {
@@ -15610,8 +14302,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "find-up": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "p-finally": "^1.0.0",
     "promise-callbacks": "^3.8.1",
-    "redis": "^2.7.1"
+    "redis": "^3.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",


### PR DESCRIPTION
- updated `redis` version to `3.1.2` which resolves https://github.com/ratehub/bee-queue/security/dependabot/12.
- updated `prettierrc` to  resolve `endOfLine` issue.